### PR TITLE
Fix dumpObjectStore to dump objects in a consistent order

### DIFF
--- a/webware/MiddleKit/Run/SQLObjectStore.py
+++ b/webware/MiddleKit/Run/SQLObjectStore.py
@@ -716,7 +716,8 @@ class SQLObjectStore(ObjectStore):
     def dumpObjectStore(self, out=None, progress=False):
         if out is None:
             out = sys.stdout
-        for klass in list(self.model().klasses().values()):
+        klasses = sorted(list(self.model().klasses().values()), key=lambda k: k.name())
+        for klass in klasses:
             if progress:
                 sys.stderr.write(".")
             out.write('%s objects\n' % (klass.name()))

--- a/webware/MiddleKit/Tests/MKDump.mkmodel/Samples.csv
+++ b/webware/MiddleKit/Tests/MKDump.mkmodel/Samples.csv
@@ -2,15 +2,15 @@ Bar objects
 barNonstandardId,name
 3,string containing spaces
 
+Baz objects
+bazNonstandardId,name,priority
+4,"string containing 'lots'' of ""quotes""
+and a newline and	a tab",10
+
 Foo objects
 fooNonstandardId,text,bar,fruit,num,isValid
 5,hello,Bar.3,apple,5,1
 6,,Baz.4,banana,,0
 7,,,banana,,0
-
-Baz objects
-bazNonstandardId,name,priority
-4,"string containing 'lots'' of ""quotes""
-and a newline and	a tab",10
 
 

--- a/webware/MiddleKit/Tests/MKDump.mkmodel/TestSamples.py
+++ b/webware/MiddleKit/Tests/MKDump.mkmodel/TestSamples.py
@@ -7,6 +7,7 @@ def test(store):
     command = 'diff -u ../MKDump.mkmodel/Samples.csv Dump.csv'
     print(command)
     retval = os.system(command)
-    retval >>= 8  # upper byte is the return code
+    if os.name == 'posix':
+        retval >>= 8  # upper byte is the return code
 
     assert retval == 0


### PR DESCRIPTION
 for better testability.  Update MKDump test to check diff return code correctly under
windows.