### PR TITLE
Update test to not expect object attributes to raise exception if you

### DIFF
--- a/webware/MiddleKit/Tests/MKTypeValueChecking.mkmodel/TestEmpty.py
+++ b/webware/MiddleKit/Tests/MKTypeValueChecking.mkmodel/TestEmpty.py
@@ -34,7 +34,7 @@ def test(store):
     typeErrors(f, blarg)
     typeErrors(f, sys.stdout)
     typeErrors(f, 1.0, ['f'])
-    typeErrors(f, 1, 'b i l f'.split())
+    typeErrors(f, 1, 'b i l f bar'.split())
 
     # ValueErrors and others
     try:


### PR DESCRIPTION
pass an integer which could be an objRef.

See issue #1.