### PR TITLE
Update version of webware required.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,10 +14,10 @@ with open('README.md') as fh:
 setuptools.setup(
     name='Webware-for-Python-MiddleKit',
     version=version,
-    author='cito, jhildeb, nl et al.',
+    author='cito, jdhildeb, nl et al.',
     author_email='nl@mnet-online.de',
     description=description,
-    install_requires=['Webware-for-Python>=3.0.0'],
+    install_requires=['Webware-for-Python>=3.0.0a0'],
     long_description=long_description,
     long_description_content_type='text/markdown',
     keywords='database orm',


### PR DESCRIPTION
The current version of Webware available is 3.0.0a0, so requiring 3.0.0 fails.
Also fix a typo in credit.